### PR TITLE
Fix Makefile so compiled .so has static name

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -3,8 +3,7 @@
 CURDIR := $(shell pwd)
 BASEDIR := $(abspath $(CURDIR)/..)
 
-PROJECT ?= $(notdir $(BASEDIR))
-PROJECT := $(strip $(PROJECT))
+PROJECT = "erl-brotli"
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
 


### PR DESCRIPTION
Otherwise, the name of the file would vary based on the name of the parent directory.

Fixes #2 

You may want to do a version bump (0.2.0?) in `brotli.app.src`, as well.