### PR TITLE
Remove hardcoded macOS arch, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ iex(1)> c ("src/brotli.erl")
 iex(2)> c ("src/brotli_nif.erl")
 [:brotli_nif]
 
-iex(3)> data = File.read!("README.md")
+iex(3)> c ("src/brotli_encoder.erl")
+[:brotli_encoder]
+
+iex(4)> data = File.read!("README.md")
 "brotli\n=====\n\nAn OTP library\n\nBuild\n-----\n\n    $ rebar3 compile\n..."
 
-iex(4)> :brotli.encode(data)
-<<27, 63, 0, 0, 4, 254, 115, 91, 127, 37, 253, 64, 37, 145, 9, 24, 138, 6, 67,
-  17, 37, 220, 118, 138, 187, 41, 76, 228, 132, 35, 13, 24, 219, 14, 32, 47, 4,
-  75, 143, 249, 185, 81, 45, 180, 71, 235, 190, 41, 53, 44, ...>>
+iex(5)> :brotli.encode(data)
+{:ok,
+ <<27, 26, 3, 0, 140, 146, 28, 142, 124, 217, 200, 164, 20, 156, 211, 199, 168,
+   156, 219, 19, 176, 219, 248, 140, 58, 157, 210, 144, 133, 150, 2, 76, 94,
+   201, 231, 55, 179, 243, 125, 215, 180, 141, 235, 59, 213, 185, 57, 61, ...>>}
 ```
 
 ### License

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -15,8 +15,8 @@ OUT ?= $(BASEDIR)/priv
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS += -O3 -std=c99 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS += -O3 -std=c99 -finline-functions -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC = /usr/bin/clang
 	CFLAGS += -O3 -std=c99 -finline-functions -Wall


### PR DESCRIPTION
The hardcoded architecture prevents the code from compiling natively on Apple Silicon, removing it seems to fix the issue.

This mirrors a fix for new rebar3 projects:
https://github.com/erlang/rebar3/pull/2656/files

While testing I've alo noticed that the `README.md` file is slightly out of date, so I've included those changes also.